### PR TITLE
Expose timeout setting in Session.

### DIFF
--- a/fritzctl/session.py
+++ b/fritzctl/session.py
@@ -152,6 +152,7 @@ class Session(object):
     :param str pwd: Optional Password for authentification
     :param int port: Port to use when connecting, defaults to ``49000``
     :param bool authcheck: If the credentials should be checked, simply requests the ``general_deviceinfo`` API.
+    :param float timeout: Timeout for requests
     
     Instance Variables:
     
@@ -161,7 +162,7 @@ class Session(object):
     :ivar device: :py:class:`simpletr64.DeviceTR64()` Instance used for managing authentification
     :ivar urns: List of URNs found on the server, can be used for debugging
     """
-    def __init__(self,server=None,user=None,pwd=None,port=49000,authcheck=True):
+    def __init__(self, server=None, user=None, pwd=None, port=49000, authcheck=True, timeout=2.0):
         if server is None:
             raise NotImplementedError("Server search is currently not implemented")
         else:
@@ -169,6 +170,7 @@ class Session(object):
         
         self.user = user if user is not None else ""
         self.pwd = pwd if pwd is not None else ""
+        self.timeout = timeout
         self.device = simpletr64.DeviceTR64(server,port=port)
         self.device.username = self.user
         self.device.password = self.pwd
@@ -227,4 +229,6 @@ class Session(object):
         
         This method simply passes through all parameters to the internal :py:class:`simpletr64.DeviceTR64()` instance.
         """
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = self.timeout
         return self.device.execute(*args,**kwargs)


### PR DESCRIPTION
Sometimes, the 2 second default timeout of simpletr64 is not enough.

I'm not sure why; I've been doing nightly requests to my box for almost 3 months with no problems. For the last 5 days, timeouts have been occurring consistently. Specs: FRITZ!Box 7490, Firmware 07.12, Installed 2019-08-26. I'm not aware of any changes in the network or usage patterns. Experimentally, I've determined that 4 seconds generally works for me now now.

This PR adds a `timeout` keyword argument to `Session.__init__`, which is passed to `simpletr64.DeviceTR64.execute`. The change should be non-breaking, as nothing is changed if a timeout argument is already passed (but nothing in fritzctl does).